### PR TITLE
Fix wrong handler names.

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 # handlers file for check-mk-agent
-- name: restart check mk service
+- name: restart checkmk service
   service:
     name: "{{ checkmk['service']['name'] }}"
     state: restarted

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -16,4 +16,4 @@
   apt:
     deb: "{{ checkmk['dest'] }}{{ checkmk['package']['name'] }}"
   notify:
-    - restart xinetd service
+    - restart checkmk service

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -1,6 +1,6 @@
 ---
 # filename: roles/checkmk/tasks/service.yml
-- name: start xinetd service
+- name: start checkmk service
   service:
     name: "{{ checkmk['service']['name'] }}"
     state: started


### PR DESCRIPTION
Hello, thanks for the role! The handler names got mixed up somehow, so ansible fails on restarting the service. I normalized them, so the playbook runs through.
